### PR TITLE
Enhancement object bounds & docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.swo
+*.swp
+.git
+.DS_Store
+node_modules
+bin
+build
+scripts
+coverage
+.nyc_output
+.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .DS_Store
 yarn.lock
 *.tar.gz
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+from lambci/lambda:build-nodejs8.10
+
+RUN yum install -y autoconf aclocal automake install libtool libjpeg-devel \
+	libpng-devel libtiff-devel zlib-devel wget gzip make cmakegcc freetype-devel \
+  gcc gcc-c++ git lcms2-devel libjpeg-turbo-devel autogen libpng-devel \
+  libtiff-devel libwebp-devel libzip-devel zlib-devel libgcc
+
+RUN yum groupinstall "Development Tools" -y
+
+RUN yum install -y cmake
+
+COPY . .
+
+RUN wget https://github.com/google/brotli/archive/v1.0.7.tar.gz
+RUN tar -zxvf v1.0.7.tar.gz
+RUN cd brotli-1.0.7 && mkdir out && cd out && ../configure-cmake && make && make test && make install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+NAME=aws-lambda-tesseract
+PWD=$(shell pwd)
+
+build: build-docker build-tesseract compress-tesseract
+
+build-dist: build-tesseract compress-tesseract
+
+build-docker:
+	docker build -f Dockerfile -t $(NAME) .
+
+version:
+	@echo $(shell git rev-parse HEAD)
+
+build-tesseract:
+	docker run -it -v $(PWD)/scripts:/scripts -v $(PWD)/build:/build -v $(PWD)/build:/build $(NAME) /scripts/compile-tesseract.sh
+
+compress-tesseract:
+	docker run -it -v $(PWD)/scripts:/scripts -v $(PWD)/build:/build $(NAME) /scripts/compress-with-brotli.sh

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,15 @@ unsupported by Tesseract file extensions.
 
 ## Compile It Yourself
 
-See [compile-tesseract.sh](compile-tesseract.sh) & [compress-with-brotli.sh](compress-with-brotli.sh) files
+Compile Tesseract for deployment on Lambda. Requires [Docker](https://www.docker.com/) & [Make](https://www.gnu.org/software/make/manual/html_node/Introduction.html) to be installed.
+
+`$ make build`: Builds Docker image, compiles Tesseract 4.0.0, and compresses result into the `tt.tar.br` archive.
+
+`$ make build-tesseract`: Compiles Tesseract 4.0.0 and creates `tesseract.tar.gz` file as output.
+
+`$ make compress-tesseract`: Runs brotli compression on built Tesseract and compresses `tesseract.tar.gz` into `tt.tar.bz`.
+
+**Note:** After compiling and compressing you need to copy the latest `tt.tar.bz` into the `/bin` directory. `$ cp ./build/tt.tar.bz ./bin`
 
 ## See Also
 

--- a/scripts/compile-tesseract.sh
+++ b/scripts/compile-tesseract.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+echo "Building"
+# Build leptonica
+wget http://www.leptonica.com/source/leptonica-1.77.0.tar.gz
+tar -zxvf leptonica-1.77.0.tar.gz
+ls -la ./
+cd leptonica-1.77.0
+ls -la 
+./configure
+make
+make install
+
+# Build tesseract 4.0
+cd ..
+wget https://github.com/tesseract-ocr/tesseract/archive/4.0.0.tar.gz
+tar -zxvf 4.0.0.tar.gz
+cd tesseract-4.0.0/
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+./autogen.sh
+./configure
+make
+make install
+ldconfig
+
+cd ~
+mkdir tesseract-standalone
+
+# trim unneeded ~ 15 MB
+strip ./tesseract-standalone/**/*
+
+# copy files
+cd tesseract-standalone
+cp /usr/local/bin/tesseract .
+mkdir lib
+cp /usr/local/lib/libtesseract.so.4 lib/
+cp /usr/local/lib/liblept.so.5 lib/
+# cp /usr/lib64/* lib/
+cp /usr/lib64/libjpeg.so.62 lib/
+cp /usr/lib64/libwebp.so.4 lib/
+cp /usr/lib64/libstdc++.so.6 lib/
+cp /usr/lib64/libpng15.so.15 lib/
+cp /usr/lib64/libtiff.so.5 lib/
+cp /usr/lib64/libgomp.so.1 lib/
+cp /usr/lib64/libjbig.so.2.0 lib/
+
+# copy training data
+mkdir tessdata
+cd tessdata
+wget https://github.com/tesseract-ocr/tessdata_fast/raw/master/eng.traineddata
+
+# Create configs
+mkdir configs
+echo "tessedit_create_tsv 1" > configs/tsv
+
+# archive
+cd ~
+tar -zcvf tesseract.tar.gz tesseract-standalone
+mv tesseract.tar.gz /build/
+
+echo "Done!"

--- a/scripts/compress-brotli.sh
+++ b/scripts/compress-brotli.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+tar -C /build -zxvf /build/tesseract.tar.gz
+mv /build/tesseract-standalone /build/tesseract
+cd /build
+tar -cf tt.tar tesseract
+rm -rf tesseract
+echo "Running brotli (this can take a few minutes)"
+brotli --best --force --verbose /build/tt.tar
+echo "Done"


### PR DESCRIPTION
This dockerizes the build process for Tesseract so new versions can be built locally without having to create an EC2 instance for building.