### PR TITLE
OPS-6570 OPS-6572 OPS-6592 Fix tar vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@shelf/prettier-config",
   "dependencies": {
     "is-image": "4.0.0",
-    "tar": "7.4.3"
+    "tar": "7.5.7"
   },
   "devDependencies": {
     "@shelf/eslint-config": "4.2.1",


### PR DESCRIPTION
## Summary

- Resolves OPS-6570 alert #7, OPS-6572 alert #9, and OPS-6592 alert #8 for `tar`.
- Updates the direct dependency from `tar@7.4.3` to exact `7.5.7`, the smallest version closing all three advisories.
- Covers GHSA-8qq5-rm4j-mr97, GHSA-34x7-hfp2-rc4v, and GHSA-r6q2-hw4h-h46w.

## Validation

- Yarn frozen install passed; the installed graph resolves only `tar@7.5.7`.
- `lint:ci` passed and all 13 tests passed.
- `git diff --check` passed.
- Type-check and build report the existing TS2688 missing minimatch type definition, reproduced identically on clean base `b58aad79f5fa37e2da736ccb4575b9cbe52463c2` and unrelated to this one-line dependency update.

Alerts: #7, #8, #9
